### PR TITLE
Use WeakMap to fix memory leaks

### DIFF
--- a/src/Elm/Kernel/Texture.js
+++ b/src/Elm/Kernel/Texture.js
@@ -6,8 +6,6 @@ import WebGL.Texture as Texture exposing (LoadError, SizeError)
 
 */
 
-var _Texture_guid = 0;
-
 // eslint-disable-next-line no-unused-vars
 var _Texture_load = F6(function (magnify, mininify, horizontalWrap, verticalWrap, flipY, url) {
   var isMipmap = mininify !== 9728 && mininify !== 9729;
@@ -41,7 +39,6 @@ var _Texture_load = F6(function (magnify, mininify, horizontalWrap, verticalWrap
       if (isSizeValid) {
         callback(__Scheduler_succeed({
           $: __0_TEXTURE,
-          id: _Texture_guid++,
           __$createTexture: createTexture,
           __width: width,
           __height: height

--- a/src/Elm/Kernel/WebGL.js
+++ b/src/Elm/Kernel/WebGL.js
@@ -608,27 +608,28 @@ function _WebGL_render(model) {
     canvas.getContext('experimental-webgl', options.contextAttributes)
   );
 
-  if (gl) {
+  if (gl && typeof WeakMap !== 'undefined') {
     options.sceneSettings.forEach(function (sceneSetting) {
       sceneSetting(gl);
     });
+
+    model.__cache.gl = gl;
+    model.__cache.shaders = [];
+    model.__cache.programs = {};
+    model.__cache.buffers = new WeakMap();
+    model.__cache.textures = new WeakMap();
+
+    // Render for the first time.
+    // This has to be done in animation frame,
+    // because the canvas is not in the DOM yet
+    _WebGL_rAF(function () {
+      return A2(_WebGL_drawGL, model, canvas);
+    });
+
   } else {
     canvas = __VirtualDom_doc.createElement('div');
     canvas.innerHTML = '<a href="https://get.webgl.org/">Enable WebGL</a> to see this content!';
   }
-
-  model.__cache.gl = gl;
-  model.__cache.shaders = [];
-  model.__cache.programs = {};
-  model.__cache.buffers = new WeakMap();
-  model.__cache.textures = new WeakMap();
-
-  // Render for the first time.
-  // This has to be done in animation frame,
-  // because the canvas is not in the DOM yet
-  _WebGL_rAF(function () {
-    return A2(_WebGL_drawGL, model, canvas);
-  });
 
   return canvas;
 }

--- a/src/Elm/Kernel/WebGL.js
+++ b/src/Elm/Kernel/WebGL.js
@@ -418,11 +418,11 @@ var _WebGL_drawGL = F2(function (model, domNode) {
 
     _WebGL_setUniforms(program.uniformSetters, entity.__uniforms);
 
-    var buffer = model.__cache.buffers[entity.__mesh.id];
+    var buffer = model.__cache.buffers.get(entity.__mesh);
 
     if (!buffer) {
       buffer = _WebGL_doBindSetup(gl, entity.__mesh);
-      model.__cache.buffers[entity.__mesh.id] = buffer;
+      model.__cache.buffers.set(entity.__mesh, buffer);
     }
 
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, buffer.indexBuffer);
@@ -494,11 +494,11 @@ function _WebGL_createUniformSetters(gl, model, program, uniformsMap) {
         var currentTexture = textureCounter++;
         return function (texture) {
           gl.activeTexture(gl.TEXTURE0 + currentTexture);
-          var tex = model.__cache.textures[texture.id];
+          var tex = model.__cache.textures.get(texture);
           if (!tex) {
             _WebGL_log('Created texture');
             tex = texture.__$createTexture(gl);
-            model.__cache.textures[texture.id] = tex;
+            model.__cache.textures.set(texture, tex);
           }
           gl.bindTexture(gl.TEXTURE_2D, tex);
           gl.uniform1i(uniformLocation, currentTexture);
@@ -509,7 +509,7 @@ function _WebGL_createUniformSetters(gl, model, program, uniformsMap) {
         };
       default:
         _WebGL_log('Unsupported uniform type: ' + uniform.type);
-        return function () {};
+        return function () { };
     }
   }
 
@@ -626,8 +626,8 @@ function _WebGL_render(model) {
   model.__cache.gl = gl;
   model.__cache.shaders = [];
   model.__cache.programs = {};
-  model.__cache.buffers = [];
-  model.__cache.textures = [];
+  model.__cache.buffers = new WeakMap();
+  model.__cache.textures = new WeakMap();
 
   // Render for the first time.
   // This has to be done in animation frame,

--- a/src/Elm/Kernel/WebGL.js
+++ b/src/Elm/Kernel/WebGL.js
@@ -31,11 +31,6 @@ var _WebGL_rAF = typeof requestAnimationFrame !== 'undefined' ?
 
 // eslint-disable-next-line no-unused-vars
 var _WebGL_entity = F5(function (settings, vert, frag, mesh, uniforms) {
-
-  if (!mesh.id) {
-    mesh.id = _WebGL_guid++;
-  }
-
   return {
     $: __0_ENTITY,
     __settings: settings,
@@ -44,7 +39,6 @@ var _WebGL_entity = F5(function (settings, vert, frag, mesh, uniforms) {
     __mesh: mesh,
     __uniforms: uniforms
   };
-
 });
 
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
Addresses memory leaks caused by many programmatically created textures and meshes: https://github.com/elm-community/webgl/issues/46

According [to spec](https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5) buffers and textures should be garbage collected together with JS objects: 
> Note that underlying GL object will be automatically marked for deletion when the JS object is destroyed, however this method allows authors to mark an object for deletion early.

It looks that browsers that support [WebGL](https://www.caniuse.com/#feat=webgl) also support [WeakMap](https://kangax.github.io/compat-table/es6/), but just in case I added a test for WeakMap support.