### PR TITLE
Add WebGL.Texture.loadBytesWith

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,10 +40,12 @@
         "F4": false,
         "F5": false,
         "F6": false,
+        "F9": false,
         "A2": false,
         "A5": false,
         "Float32Array": false,
         "Int32Array": false,
-        "Uint16Array": false
+        "Uint16Array": false,
+        "Uint8Array": false
     }
 }

--- a/elm.json
+++ b/elm.json
@@ -14,6 +14,7 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
+        "elm/bytes": "1.0.8 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0"
     },

--- a/src/Elm/Kernel/Texture.js
+++ b/src/Elm/Kernel/Texture.js
@@ -65,3 +65,31 @@ var _Texture_load = F6(function (magnify, mininify, horizontalWrap, verticalWrap
 var _Texture_size = function (texture) {
   return __Utils_Tuple2(texture.__width, texture.__height);
 };
+
+
+//Texture Loading from Bytes
+
+// eslint-disable-next-line no-unused-vars
+var _Texture_loadBytes = F9(function (magnify, mininify, horizontalWrap, verticalWrap, flipY, width, height, pixelFormat, bytes) {
+  function createTexture(gl) {
+    var texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
+    gl.texImage2D(gl.TEXTURE_2D, 0, pixelFormat, width, height, 0, pixelFormat, gl.UNSIGNED_BYTE, new Uint8Array(bytes.buffer));
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, magnify);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, mininify);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, horizontalWrap);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, verticalWrap);
+    if (mininify !== 9728 && mininify !== 9729) {
+      gl.generateMipmap(gl.TEXTURE_2D);
+    }
+    gl.bindTexture(gl.TEXTURE_2D, null);
+    return texture;
+  }
+  return {
+    $: __0_TEXTURE,
+    __$createTexture: createTexture,
+    __width: width,
+    __height: height
+  };
+});


### PR DESCRIPTION
adding ability to create textures out of bytes, this is task less api, for future it will allow as create custom image / scene format loaders, create default texture without waiting for task.
```elm       
        pixelBytes =
            List.repeat 2 (Bytes.unsignedInt32 Bytes.BE 0xFF0000FF)
                |> (++) (List.repeat 18 (Bytes.unsignedInt32 Bytes.BE 0xFFFF))
                |> Bytes.sequence
                |> Bytes.encode

        resultTexture =
            WebGL.loadBytesWith WebGL.nonPowerOfTwoOptions ( 2, 10 ) RGBA pixelBytes
```