### PR TITLE
Fix resetting write masks for the depth and stencil buffers

### DIFF
--- a/src/Elm/Kernel/WebGL.js
+++ b/src/Elm/Kernel/WebGL.js
@@ -116,6 +116,7 @@ var _WebGL_disableBlend = function (gl) {
 // eslint-disable-next-line no-unused-vars
 var _WebGL_disableDepthTest = function (gl) {
   gl.disable(gl.DEPTH_TEST);
+  gl.depthMask(true);
 };
 
 // eslint-disable-next-line no-unused-vars

--- a/src/Elm/Kernel/WebGL.js
+++ b/src/Elm/Kernel/WebGL.js
@@ -109,49 +109,50 @@ var _WebGL_enableSampleAlphaToCoverage = F2(function (gl, setting) {
 });
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_disableBlend = function (gl) {
-  gl.disable(gl.BLEND);
+var _WebGL_disableBlend = function (cache) {
+  cache.gl.disable(cache.gl.BLEND);
 };
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_disableDepthTest = function (gl) {
-  gl.disable(gl.DEPTH_TEST);
-  gl.depthMask(true);
+var _WebGL_disableDepthTest = function (cache) {
+  cache.gl.disable(cache.gl.DEPTH_TEST);
+  cache.gl.depthMask(true);
 };
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_disableStencilTest = function (gl) {
-  gl.disable(gl.STENCIL_TEST);
+var _WebGL_disableStencilTest = function (cache) {
+  cache.gl.disable(cache.gl.STENCIL_TEST);
+  cache.gl.stencilMask(cache.STENCIL_WRITEMASK);
 };
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_disableScissor = function (gl) {
-  gl.disable(gl.SCISSOR_TEST);
+var _WebGL_disableScissor = function (cache) {
+  cache.gl.disable(cache.gl.SCISSOR_TEST);
 };
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_disableColorMask = function (gl) {
-  gl.colorMask(true, true, true, true);
+var _WebGL_disableColorMask = function (cache) {
+  cache.gl.colorMask(true, true, true, true);
 };
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_disableCullFace = function (gl) {
-  gl.disable(gl.CULL_FACE);
+var _WebGL_disableCullFace = function (cache) {
+  cache.gl.disable(cache.gl.CULL_FACE);
 };
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_disablePolygonOffset = function (gl) {
-  gl.disable(gl.POLYGON_OFFSET_FILL);
+var _WebGL_disablePolygonOffset = function (cache) {
+  cache.gl.disable(cache.gl.POLYGON_OFFSET_FILL);
 };
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_disableSampleCoverage = function (gl) {
-  gl.disable(gl.SAMPLE_COVERAGE);
+var _WebGL_disableSampleCoverage = function (cache) {
+  cache.gl.disable(cache.gl.SAMPLE_COVERAGE);
 };
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_disableSampleAlphaToCoverage = function (gl) {
-  gl.disable(gl.SAMPLE_ALPHA_TO_COVERAGE);
+var _WebGL_disableSampleAlphaToCoverage = function (cache) {
+  cache.gl.disable(cache.gl.SAMPLE_ALPHA_TO_COVERAGE);
 };
 
 function _WebGL_doCompile(gl, src, type) {
@@ -447,15 +448,11 @@ var _WebGL_drawGL = F2(function (model, domNode) {
         }
       }
     }
-    _WebGL_listEach(function (setting) {
-      return A2(__WI_enableSetting, gl, setting);
-    }, entity.__settings);
+    _WebGL_listEach(__WI_enableSetting(gl), entity.__settings);
 
     gl.drawElements(entity.__mesh.a.__$mode, buffer.numIndices, gl.UNSIGNED_SHORT, 0);
 
-    _WebGL_listEach(function (setting) {
-      return A2(__WI_disableSetting, gl, setting);
-    }, entity.__settings);
+    _WebGL_listEach(__WI_disableSetting(model.__cache), entity.__settings);
 
   }
 
@@ -632,6 +629,9 @@ function _WebGL_render(model) {
     model.__cache.programs = {};
     model.__cache.buffers = new WeakMap();
     model.__cache.textures = new WeakMap();
+    // Memorize the initial stencil write mask, because
+    // browsers may have different number of stencil bits
+    model.__cache.STENCIL_WRITEMASK = gl.getParameter(gl.STENCIL_WRITEMASK);
 
     // Render for the first time.
     // This has to be done in animation frame,

--- a/src/WebGL/Internal.elm
+++ b/src/WebGL/Internal.elm
@@ -84,31 +84,31 @@ enableSetting gl setting =
 
 
 disableSetting : () -> Setting -> ()
-disableSetting gl setting =
+disableSetting cache setting =
     case setting of
         Blend _ _ _ _ _ _ _ _ _ _ ->
-            Elm.Kernel.WebGL.disableBlend gl
+            Elm.Kernel.WebGL.disableBlend cache
 
         DepthTest _ _ _ _ ->
-            Elm.Kernel.WebGL.disableDepthTest gl
+            Elm.Kernel.WebGL.disableDepthTest cache
 
         StencilTest _ _ _ _ _ _ _ _ _ _ _ ->
-            Elm.Kernel.WebGL.disableStencilTest gl
+            Elm.Kernel.WebGL.disableStencilTest cache
 
         Scissor _ _ _ _ ->
-            Elm.Kernel.WebGL.disableScissor gl
+            Elm.Kernel.WebGL.disableScissor cache
 
         ColorMask _ _ _ _ ->
-            Elm.Kernel.WebGL.disableColorMask gl
+            Elm.Kernel.WebGL.disableColorMask cache
 
         CullFace _ ->
-            Elm.Kernel.WebGL.disableCullFace gl
+            Elm.Kernel.WebGL.disableCullFace cache
 
         PolygonOffset _ _ ->
-            Elm.Kernel.WebGL.disablePolygonOffset gl
+            Elm.Kernel.WebGL.disablePolygonOffset cache
 
         SampleCoverage _ _ ->
-            Elm.Kernel.WebGL.disableSampleCoverage gl
+            Elm.Kernel.WebGL.disableSampleCoverage cache
 
         SampleAlphaToCoverage ->
-            Elm.Kernel.WebGL.disableSampleAlphaToCoverage gl
+            Elm.Kernel.WebGL.disableSampleAlphaToCoverage cache


### PR DESCRIPTION
The `gl.clear` depends on the ability to write into the stencil or depth buffer. This is controlled by the corresponding write masks (`gl.depthMask` and `gl.stencilMask`), that weren’t correctly reset after each entity. This caused a bug: if the last entity disables writing to the depth or the stencil buffers, then this prevents the corresponding buffer from being cleared for the next frame.

This pr properly resets the depth and stencil masks. The depth mask is set to `true`. The stencil mask is set to the initial value, because it is a bit mask and different browsers have different number of stencil bits.