### PR TITLE
Added support for WebGL 2.0 (and possibility of GLSL 3.0 support)

### DIFF
--- a/src/Elm/Kernel/WebGL.js
+++ b/src/Elm/Kernel/WebGL.js
@@ -608,9 +608,13 @@ function _WebGL_render(model) {
   _WebGL_log('Render canvas');
   var canvas = __VirtualDom_doc.createElement('canvas');
   var gl = canvas.getContext && (
+    canvas.getContext('webgl2', options.contextAttributes) ||
     canvas.getContext('webgl', options.contextAttributes) ||
     canvas.getContext('experimental-webgl', options.contextAttributes)
   );
+
+  _WebGL_log('WebGL version: ' + gl.getParameter(gl.VERSION));
+  _WebGL_log('GLSL version: ' + gl.getParameter(gl.SHADING_LANGUAGE_VERSION));
 
   if (gl && typeof WeakMap !== 'undefined') {
     options.sceneSettings.forEach(function (sceneSetting) {


### PR DESCRIPTION
This adds support for WebGL 2.0. Among other things, this opens up the possibility of supporting GLSL 3.0.

I believe my change is backwards compatible with WebGL <2.0 as far as the existing `webgl` API goes, but I have not yet tested this. The logging code I added should show that the correct version is, in fact, being used (when logging is enabled by uncommenting the logging function body).

Based on [this list](https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.1) of backwards incompatibilities between WebGL 2.0 and WebGL 1.0, it sounds like most of them are just WebGL 2.0 being more _lenient_ about certain things. It does not sound like the other incompatibilities apply here, since I do not see `DEPTH_ATTACHMENT`, etc, being used in this package (though I could be mistaken).



A side-note about GLSL 3.0: At the moment, there is an issue upstream with the GLSL parser package used by the Elm compiler which I believe is preventing GLSL 3.0 from being used (even with the change here). I will see if I can patch this package as well. [This](https://github.com/noteed/language-glsl/issues/4) is the relevant issue on that package. [GLSL assumes that version 1.10 is being used, unless a `#version` preprocessor directive says otherwise](https://www.khronos.org/opengl/wiki/Core_Language_(GLSL)#Version).

It is worth noting that GLSL 1.10 is 15 years old.