### PR TITLE
Performance improvements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,6 @@
         "__Texture_LoadError": false,
         "__Utils_Tuple2": false,
         "__WI_enableSetting": false,
-        "__WI_disableSetting": false,
         "__WI_enableOption": false,
         "__0_ENTITY": false,
         "__0_TEXTURE": false,
@@ -44,6 +43,7 @@
         "A5": false,
         "Float32Array": false,
         "Int32Array": false,
-        "Uint16Array": false
+        "Uint16Array": false,
+        "WeakMap": false
     }
 }

--- a/src/Elm/Kernel/WebGL.js
+++ b/src/Elm/Kernel/WebGL.js
@@ -5,10 +5,6 @@ import WebGL.Internal as WI exposing (enableSetting, enableOption)
 
 */
 
-function _WebGL_log(/* msg */) {
-  // console.log(msg);
-}
-
 var _WebGL_guid = 0;
 
 function _WebGL_listEach(fn, list) {
@@ -285,10 +281,7 @@ var _WebGL_settings = ['blend', 'depthTest', 'stencilTest', 'scissor', 'colorMas
 var _WebGL_disableFunctions = [_WebGL_disableBlend, _WebGL_disableDepthTest, _WebGL_disableStencilTest, _WebGL_disableScissor, _WebGL_disableColorMask, _WebGL_disableCullFace, _WebGL_disablePolygonOffset, _WebGL_disableSampleCoverage, _WebGL_disableSampleAlphaToCoverage];
 
 function _WebGL_doCompile(gl, src, type) {
-
   var shader = gl.createShader(type);
-  _WebGL_log('Created shader');
-
   gl.shaderSource(shader, src);
   gl.compileShader(shader);
   if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
@@ -296,13 +289,10 @@ function _WebGL_doCompile(gl, src, type) {
   }
 
   return shader;
-
 }
 
 function _WebGL_doLink(gl, vshader, fshader) {
-
   var program = gl.createProgram();
-  _WebGL_log('Created program');
 
   gl.attachShader(program, vshader);
   gl.attachShader(program, fshader);
@@ -312,7 +302,6 @@ function _WebGL_doLink(gl, vshader, fshader) {
   }
 
   return program;
-
 }
 
 function _WebGL_getAttributeInfo(gl, type) {
@@ -385,8 +374,6 @@ function _WebGL_doBindAttribute(gl, attribute, mesh, attributes) {
   }, mesh.b);
 
   var buffer = gl.createBuffer();
-  _WebGL_log('Created attribute buffer ' + attribute.name);
-
   gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
   gl.bufferData(gl.ARRAY_BUFFER, array, gl.STATIC_DRAW);
   return buffer;
@@ -411,7 +398,6 @@ function _WebGL_doBindAttribute(gl, attribute, mesh, attributes) {
  */
 function _WebGL_doBindSetup(gl, mesh) {
   if (mesh.a.__$indexSize > 0) {
-    _WebGL_log('Created index buffer');
     var indexBuffer = gl.createBuffer();
     var indices = _WebGL_makeIndexedBuffer(mesh.c, mesh.a.__$indexSize);
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
@@ -459,7 +445,6 @@ function _WebGL_getProgID(vertID, fragID) {
 }
 
 var _WebGL_drawGL = F2(function (model, domNode) {
-
   var cache = model.__cache;
   var gl = cache.gl;
 
@@ -469,7 +454,6 @@ var _WebGL_drawGL = F2(function (model, domNode) {
 
   gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
   gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
-  _WebGL_log('Drawing');
 
   function drawEntity(entity) {
     if (!entity.__mesh.b.b) {
@@ -658,7 +642,6 @@ function _WebGL_createUniformSetters(gl, model, program, uniformsMap) {
             gl.activeTexture(gl.TEXTURE0 + currentTexture);
             var tex = cache.textures.get(texture);
             if (!tex) {
-              _WebGL_log('Created texture');
               tex = texture.__$createTexture(gl);
               cache.textures.set(texture, tex);
             }
@@ -675,7 +658,6 @@ function _WebGL_createUniformSetters(gl, model, program, uniformsMap) {
           }
         };
       default:
-        _WebGL_log('Unsupported uniform type: ' + uniform.type);
         return function () { };
     }
   }
@@ -780,7 +762,6 @@ function _WebGL_render(model) {
     return A2(__WI_enableOption, options, option);
   }, model.__options);
 
-  _WebGL_log('Render canvas');
   var canvas = __VirtualDom_doc.createElement('canvas');
   var gl = canvas.getContext && (
     canvas.getContext('webgl', options.contextAttributes) ||

--- a/src/Elm/Kernel/WebGL.js
+++ b/src/Elm/Kernel/WebGL.js
@@ -384,7 +384,9 @@ var _WebGL_drawGL = F2(function (model, domNode) {
       program = {
         glProgram: glProgram,
         attributes: Object.assign({}, entity.__vert.attributes, entity.__frag.attributes),
-        currentUniforms: {}
+        currentUniforms: {},
+        activeAttributes: [],
+        activeAttributeLocations: []
       };
 
       program.uniformSetters = _WebGL_createUniformSetters(
@@ -393,6 +395,14 @@ var _WebGL_drawGL = F2(function (model, domNode) {
         program,
         Object.assign({}, entity.__vert.uniforms, entity.__frag.uniforms)
       );
+
+      var numActiveAttributes = gl.getProgramParameter(glProgram, gl.ACTIVE_ATTRIBUTES);
+      for (var i = 0; i < numActiveAttributes; i++) {
+        var attribute = gl.getActiveAttrib(glProgram, i);
+        var attribLocation = gl.getAttribLocation(glProgram, attribute.name);
+        program.activeAttributes.push(attribute);
+        program.activeAttributeLocations.push(attribLocation);
+      }
 
       progid = _WebGL_getProgID(entity.__vert.id, entity.__frag.id);
       model.__cache.programs[progid] = program;
@@ -410,23 +420,18 @@ var _WebGL_drawGL = F2(function (model, domNode) {
       model.__cache.buffers.set(entity.__mesh, buffer);
     }
 
-    var numAttributes = gl.getProgramParameter(program.glProgram, gl.ACTIVE_ATTRIBUTES);
-
-    for (var i = 0; i < numAttributes; i++) {
-      var attribute = gl.getActiveAttrib(program.glProgram, i);
-
-      var attribLocation = gl.getAttribLocation(program.glProgram, attribute.name);
-      gl.enableVertexAttribArray(attribLocation);
+    for (var i = 0; i < program.activeAttributes.length; i++) {
+      var attribute = program.activeAttributes[i];
+      var attribLocation = program.activeAttributeLocations[i];
 
       if (buffer.buffers[attribute.name] === undefined) {
         buffer.buffers[attribute.name] = _WebGL_doBindAttribute(gl, attribute, entity.__mesh, program.attributes);
       }
-      var attributeBuffer = buffer.buffers[attribute.name];
+      gl.bindBuffer(gl.ARRAY_BUFFER, buffer.buffers[attribute.name]);
+
       var attributeInfo = _WebGL_getAttributeInfo(gl, attribute.type);
-
-      gl.bindBuffer(gl.ARRAY_BUFFER, attributeBuffer);
-
       if (attributeInfo.arraySize === 1) {
+        gl.enableVertexAttribArray(attribLocation);
         gl.vertexAttribPointer(attribLocation, attributeInfo.size, attributeInfo.baseType, false, 0, 0);
       } else {
         // Point to four vec4 in case of mat4

--- a/src/Elm/Kernel/WebGL.js
+++ b/src/Elm/Kernel/WebGL.js
@@ -384,13 +384,15 @@ var _WebGL_drawGL = F2(function (model, domNode) {
       program = {
         glProgram: glProgram,
         attributes: Object.assign({}, entity.__vert.attributes, entity.__frag.attributes),
-        uniformSetters: _WebGL_createUniformSetters(
-          gl,
-          model,
-          glProgram,
-          Object.assign({}, entity.__vert.uniforms, entity.__frag.uniforms)
-        )
+        currentUniforms: {}
       };
+
+      program.uniformSetters = _WebGL_createUniformSetters(
+        gl,
+        model,
+        program,
+        Object.assign({}, entity.__vert.uniforms, entity.__frag.uniforms)
+      );
 
       progid = _WebGL_getProgID(entity.__vert.id, entity.__frag.id);
       model.__cache.programs[progid] = program;
@@ -454,50 +456,77 @@ var _WebGL_drawGL = F2(function (model, domNode) {
 });
 
 function _WebGL_createUniformSetters(gl, model, program, uniformsMap) {
+  var glProgram = program.glProgram;
+  var currentUniforms = program.currentUniforms;
   var textureCounter = 0;
-  function createUniformSetter(program, uniform) {
-    var uniformLocation = gl.getUniformLocation(program, uniform.name);
+  function createUniformSetter(glProgram, uniform) {
+    var uniformName = uniform.name;
+    var uniformLocation = gl.getUniformLocation(glProgram, uniformName);
     switch (uniform.type) {
       case gl.INT:
         return function (value) {
-          gl.uniform1i(uniformLocation, value);
+          if (currentUniforms[uniformName] !== value) {
+            gl.uniform1i(uniformLocation, value);
+            currentUniforms[uniformName] = value;
+          }
         };
       case gl.FLOAT:
         return function (value) {
-          gl.uniform1f(uniformLocation, value);
+          if (currentUniforms[uniformName] !== value) {
+            gl.uniform1f(uniformLocation, value);
+            currentUniforms[uniformName] = value;
+          }
         };
       case gl.FLOAT_VEC2:
         return function (value) {
-          gl.uniform2fv(uniformLocation, new Float32Array(value));
+          if (currentUniforms[uniformName] !== value) {
+            gl.uniform2f(uniformLocation, value[0], value[1]);
+            currentUniforms[uniformName] = value;
+          }
         };
       case gl.FLOAT_VEC3:
         return function (value) {
-          gl.uniform3fv(uniformLocation, new Float32Array(value));
+          if (currentUniforms[uniformName] !== value) {
+            gl.uniform3f(uniformLocation, value[0], value[1], value[2]);
+            currentUniforms[uniformName] = value;
+          }
         };
       case gl.FLOAT_VEC4:
         return function (value) {
-          gl.uniform4fv(uniformLocation, new Float32Array(value));
+          if (currentUniforms[uniformName] !== value) {
+            gl.uniform4f(uniformLocation, value[0], value[1], value[2], value[3]);
+            currentUniforms[uniformName] = value;
+          }
         };
       case gl.FLOAT_MAT4:
         return function (value) {
-          gl.uniformMatrix4fv(uniformLocation, false, new Float32Array(value));
+          if (currentUniforms[uniformName] !== value) {
+            gl.uniformMatrix4fv(uniformLocation, false, new Float32Array(value));
+            currentUniforms[uniformName] = value;
+          }
         };
       case gl.SAMPLER_2D:
         var currentTexture = textureCounter++;
         return function (texture) {
-          gl.activeTexture(gl.TEXTURE0 + currentTexture);
-          var tex = model.__cache.textures.get(texture);
-          if (!tex) {
-            _WebGL_log('Created texture');
-            tex = texture.__$createTexture(gl);
-            model.__cache.textures.set(texture, tex);
+          if (currentUniforms[uniformName] !== value) {
+            gl.activeTexture(gl.TEXTURE0 + currentTexture);
+            var tex = model.__cache.textures.get(texture);
+            if (!tex) {
+              _WebGL_log('Created texture');
+              tex = texture.__$createTexture(gl);
+              model.__cache.textures.set(texture, tex);
+            }
+            gl.bindTexture(gl.TEXTURE_2D, tex);
+            gl.uniform1i(uniformLocation, currentTexture);
+            currentUniforms[uniformName] = texture;
           }
-          gl.bindTexture(gl.TEXTURE_2D, tex);
-          gl.uniform1i(uniformLocation, currentTexture);
         };
       case gl.BOOL:
         return function (value) {
-          gl.uniform1i(uniformLocation, value);
+          if (currentUniforms[uniformName] !== value) {
+            gl.uniform1i(uniformLocation, value);
+            currentUniforms[uniformName] = texture;
+          }
         };
       default:
         _WebGL_log('Unsupported uniform type: ' + uniform.type);
@@ -506,10 +535,10 @@ function _WebGL_createUniformSetters(gl, model, program, uniformsMap) {
   }
 
   var uniformSetters = {};
-  var numUniforms = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS);
+  var numUniforms = gl.getProgramParameter(glProgram, gl.ACTIVE_UNIFORMS);
   for (var i = 0; i < numUniforms; i++) {
-    var uniform = gl.getActiveUniform(program, i);
-    uniformSetters[uniformsMap[uniform.name] || uniform.name] = createUniformSetter(program, uniform);
+    var uniform = gl.getActiveUniform(glProgram, i);
+    uniformSetters[uniformsMap[uniform.name] || uniform.name] = createUniformSetter(glProgram, uniform);
   }
 
   return uniformSetters;

--- a/src/Elm/Kernel/WebGL.js
+++ b/src/Elm/Kernel/WebGL.js
@@ -1,7 +1,7 @@
 /*
 
 import Elm.Kernel.VirtualDom exposing (custom, doc)
-import WebGL.Internal as WI exposing (enableSetting, disableSetting, enableOption)
+import WebGL.Internal as WI exposing (enableSetting, enableOption)
 
 */
 
@@ -42,118 +42,247 @@ var _WebGL_entity = F5(function (settings, vert, frag, mesh, uniforms) {
 });
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_enableBlend = F2(function (gl, setting) {
-  gl.enable(gl.BLEND);
+var _WebGL_enableBlend = F2(function (cache, setting) {
+  var blend = cache.blend;
+  blend.toggle = cache.toggle;
+
+  if (!blend.enabled) {
+    cache.gl.enable(cache.gl.BLEND);
+    blend.enabled = true;
+  }
+
   // a   b   c   d   e   f   g h i j
   // eq1 f11 f12 eq2 f21 f22 r g b a
-  gl.blendEquationSeparate(setting.a, setting.d);
-  gl.blendFuncSeparate(setting.b, setting.c, setting.e, setting.f);
-  gl.blendColor(setting.g, setting.h, setting.i, setting.j);
+  if (blend.a !== setting.a || blend.d !== setting.d) {
+    cache.gl.blendEquationSeparate(setting.a, setting.d);
+    blend.a = setting.a;
+    blend.d = setting.d;
+  }
+  if (blend.b !== setting.b || blend.c !== setting.c || blend.e !== setting.e || blend.f !== setting.f) {
+    cache.gl.blendFuncSeparate(setting.b, setting.c, setting.e, setting.f);
+    blend.b = setting.b;
+    blend.c = setting.c;
+    blend.e = setting.e;
+    blend.f = setting.f;
+  }
+  if (blend.g !== setting.g || blend.h !== setting.h || blend.i !== setting.i || blend.j !== setting.j) {
+    cache.gl.blendColor(setting.g, setting.h, setting.i, setting.j);
+    blend.g = setting.g;
+    blend.h = setting.h;
+    blend.i = setting.i;
+    blend.j = setting.j;
+  }
 });
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_enableDepthTest = F2(function (gl, setting) {
-  gl.enable(gl.DEPTH_TEST);
+var _WebGL_enableDepthTest = F2(function (cache, setting) {
+  var depthTest = cache.depthTest;
+  depthTest.toggle = cache.toggle;
+
+  if (!depthTest.enabled) {
+    cache.gl.enable(cache.gl.DEPTH_TEST);
+    depthTest.enabled = true;
+  }
+
   // a    b    c    d
   // func mask near far
-  gl.depthFunc(setting.a);
-  gl.depthMask(setting.b);
-  gl.depthRange(setting.c, setting.d);
+  if (depthTest.a !== setting.a) {
+    cache.gl.depthFunc(setting.a);
+    depthTest.a = setting.a;
+  }
+  if (depthTest.b !== setting.b) {
+    cache.gl.depthMask(setting.b);
+    depthTest.b = setting.b;
+  }
+  if (depthTest.c !== setting.c || depthTest.d !== setting.d) {
+    cache.gl.depthRange(setting.c, setting.d);
+    depthTest.c = setting.c;
+    depthTest.d = setting.d;
+  }
 });
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_enableStencilTest = F2(function (gl, setting) {
-  gl.enable(gl.STENCIL_TEST);
+var _WebGL_enableStencilTest = F2(function (cache, setting) {
+  var stencilTest = cache.stencilTest;
+  stencilTest.toggle = cache.toggle;
+
+  if (!stencilTest.enabled) {
+    cache.gl.enable(cache.gl.STENCIL_TEST);
+    stencilTest.enabled = true;
+  }
+
   // a   b    c         d     e     f      g      h     i     j      k
   // ref mask writeMask test1 fail1 zfail1 zpass1 test2 fail2 zfail2 zpass2
-  gl.stencilFuncSeparate(gl.FRONT, setting.d, setting.a, setting.b);
-  gl.stencilOpSeparate(gl.FRONT, setting.e, setting.f, setting.g);
-  gl.stencilMaskSeparate(gl.FRONT, setting.c);
-  gl.stencilFuncSeparate(gl.BACK, setting.h, setting.a, setting.b);
-  gl.stencilOpSeparate(gl.BACK, setting.i, setting.j, setting.k);
-  gl.stencilMaskSeparate(gl.BACK, setting.c);
+  if (stencilTest.d !== setting.d || stencilTest.a !== setting.a || stencilTest.b !== setting.b) {
+    cache.gl.stencilFuncSeparate(cache.gl.FRONT, setting.d, setting.a, setting.b);
+    stencilTest.d = setting.d;
+    // a and b are set in the cache.gl.BACK diffing because they should be the same
+  }
+  if (stencilTest.e !== setting.e || stencilTest.f !== setting.f || stencilTest.g !== setting.g) {
+    cache.gl.stencilOpSeparate(cache.gl.FRONT, setting.e, setting.f, setting.g);
+    stencilTest.e = setting.e;
+    stencilTest.f = setting.f;
+    stencilTest.g = setting.g;
+  }
+  if (stencilTest.c !== setting.c) {
+    cache.gl.stencilMask(setting.c);
+    stencilTest.c = setting.c;
+  }
+  if (stencilTest.h !== setting.h || stencilTest.a !== setting.a || stencilTest.b !== setting.b) {
+    cache.gl.stencilFuncSeparate(cache.gl.BACK, setting.h, setting.a, setting.b);
+    stencilTest.h = setting.h;
+    stencilTest.a = setting.a;
+    stencilTest.b = setting.b;
+  }
+  if (stencilTest.i !== setting.i || stencilTest.j !== setting.j || stencilTest.k !== setting.k) {
+    cache.gl.stencilOpSeparate(cache.gl.BACK, setting.i, setting.j, setting.k);
+    stencilTest.i = setting.i;
+    stencilTest.j = setting.j;
+    stencilTest.k = setting.k;
+  }
 });
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_enableScissor = F2(function (gl, setting) {
-  gl.enable(gl.SCISSOR_TEST);
-  gl.scissor(setting.a, setting.b, setting.c, setting.d);
+var _WebGL_enableScissor = F2(function (cache, setting) {
+  var scissor = cache.scissor;
+  scissor.toggle = cache.toggle;
+
+  if (!scissor.enabled) {
+    cache.gl.enable(cache.gl.SCISSOR_TEST);
+    scissor.enabled = true;
+  }
+
+  if (scissor.a !== setting.a || scissor.b !== setting.b || scissor.c !== setting.c || scissor.d !== setting.d) {
+    cache.gl.scissor(setting.a, setting.b, setting.c, setting.d);
+    scissor.a = setting.a;
+    scissor.b = setting.b;
+    scissor.c = setting.c;
+    scissor.d = setting.d;
+  }
 });
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_enableColorMask = F2(function (gl, setting) {
-  gl.colorMask(setting.a, setting.b, setting.c, setting.d);
+var _WebGL_enableColorMask = F2(function (cache, setting) {
+  var colorMask = cache.colorMask;
+  colorMask.toggle = cache.toggle;
+  colorMask.enabled = true;
+
+  if (colorMask.a !== setting.a || colorMask.b !== setting.b || colorMask.c !== setting.c || colorMask.d !== setting.d) {
+    cache.gl.colorMask(setting.a, setting.b, setting.c, setting.d);
+    colorMask.a = setting.a;
+    colorMask.b = setting.b;
+    colorMask.c = setting.c;
+    colorMask.d = setting.d;
+  }
 });
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_enableCullFace = F2(function (gl, setting) {
-  gl.enable(gl.CULL_FACE);
-  gl.cullFace(setting.a);
+var _WebGL_enableCullFace = F2(function (cache, setting) {
+  var cullFace = cache.cullFace;
+  cullFace.toggle = cache.toggle;
+
+  if (!cullFace.enabled) {
+    cache.gl.enable(cache.gl.CULL_FACE);
+    cullFace.enabled = true;
+  }
+
+  if (cullFace.a !== setting.a) {
+    cache.gl.cullFace(setting.a);
+    cullFace.a = setting.a;
+  }
 });
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_enablePolygonOffset = F2(function (gl, setting) {
-  gl.enable(gl.POLYGON_OFFSET_FILL);
-  gl.polygonOffset(setting.a, setting.b);
+var _WebGL_enablePolygonOffset = F2(function (cache, setting) {
+  var polygonOffset = cache.polygonOffset;
+  polygonOffset.toggle = cache.toggle;
+
+  if (!polygonOffset.enabled) {
+    cache.gl.enable(cache.gl.POLYGON_OFFSET_FILL);
+    polygonOffset.enabled = true;
+  }
+
+  if (polygonOffset.a !== setting.a || polygonOffset.b !== setting.b) {
+    cache.gl.polygonOffset(setting.a, setting.b);
+    polygonOffset.a = setting.a;
+    polygonOffset.b = setting.b;
+  }
 });
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_enableSampleCoverage = F2(function (gl, setting) {
-  gl.enable(gl.SAMPLE_COVERAGE);
-  gl.sampleCoverage(setting.a, setting.b);
+var _WebGL_enableSampleCoverage = F2(function (cache, setting) {
+  var sampleCoverage = cache.sampleCoverage;
+  sampleCoverage.toggle = cache.toggle;
+
+  if (!sampleCoverage.enabled) {
+    cache.gl.enable(cache.gl.SAMPLE_COVERAGE);
+    sampleCoverage.enabled = true;
+  }
+
+  if (sampleCoverage.a !== setting.a || sampleCoverage.b !== setting.b) {
+    cache.gl.sampleCoverage(setting.a, setting.b);
+    sampleCoverage.a = setting.a;
+    sampleCoverage.b = setting.b;
+  }
 });
 
 // eslint-disable-next-line no-unused-vars
-var _WebGL_enableSampleAlphaToCoverage = F2(function (gl, setting) {
-  gl.enable(gl.SAMPLE_ALPHA_TO_COVERAGE);
-});
+var _WebGL_enableSampleAlphaToCoverage = function (cache) {
+  var sampleAlphaToCoverage = cache.sampleAlphaToCoverage;
+  sampleAlphaToCoverage.toggle = cache.toggle;
 
-// eslint-disable-next-line no-unused-vars
+  if (!sampleAlphaToCoverage.enabled) {
+    cache.gl.enable(cache.gl.SAMPLE_ALPHA_TO_COVERAGE);
+    sampleAlphaToCoverage.enabled = true;
+  }
+};
+
 var _WebGL_disableBlend = function (cache) {
   cache.gl.disable(cache.gl.BLEND);
 };
 
-// eslint-disable-next-line no-unused-vars
 var _WebGL_disableDepthTest = function (cache) {
   cache.gl.disable(cache.gl.DEPTH_TEST);
   cache.gl.depthMask(true);
+  cache.depthTest.b = true;
 };
 
-// eslint-disable-next-line no-unused-vars
 var _WebGL_disableStencilTest = function (cache) {
   cache.gl.disable(cache.gl.STENCIL_TEST);
   cache.gl.stencilMask(cache.STENCIL_WRITEMASK);
+  cache.stencilTest.c = cache.STENCIL_WRITEMASK;
 };
 
-// eslint-disable-next-line no-unused-vars
 var _WebGL_disableScissor = function (cache) {
   cache.gl.disable(cache.gl.SCISSOR_TEST);
 };
 
-// eslint-disable-next-line no-unused-vars
 var _WebGL_disableColorMask = function (cache) {
   cache.gl.colorMask(true, true, true, true);
+  cache.colorMask.a = true;
+  cache.colorMask.b = true;
+  cache.colorMask.c = true;
+  cache.colorMask.d = true;
 };
 
-// eslint-disable-next-line no-unused-vars
 var _WebGL_disableCullFace = function (cache) {
   cache.gl.disable(cache.gl.CULL_FACE);
 };
 
-// eslint-disable-next-line no-unused-vars
 var _WebGL_disablePolygonOffset = function (cache) {
   cache.gl.disable(cache.gl.POLYGON_OFFSET_FILL);
 };
 
-// eslint-disable-next-line no-unused-vars
 var _WebGL_disableSampleCoverage = function (cache) {
   cache.gl.disable(cache.gl.SAMPLE_COVERAGE);
 };
 
-// eslint-disable-next-line no-unused-vars
 var _WebGL_disableSampleAlphaToCoverage = function (cache) {
   cache.gl.disable(cache.gl.SAMPLE_ALPHA_TO_COVERAGE);
 };
+
+var _WebGL_settings = ['blend', 'depthTest', 'stencilTest', 'scissor', 'colorMask', 'cullFace', 'polygonOffset', 'sampleCoverage', 'sampleAlphaToCoverage'];
+var _WebGL_disableFunctions = [_WebGL_disableBlend, _WebGL_disableDepthTest, _WebGL_disableStencilTest, _WebGL_disableScissor, _WebGL_disableColorMask, _WebGL_disableCullFace, _WebGL_disablePolygonOffset, _WebGL_disableSampleCoverage, _WebGL_disableSampleAlphaToCoverage];
 
 function _WebGL_doCompile(gl, src, type) {
 
@@ -331,7 +460,8 @@ function _WebGL_getProgID(vertID, fragID) {
 
 var _WebGL_drawGL = F2(function (model, domNode) {
 
-  var gl = model.__cache.gl;
+  var cache = model.__cache;
+  var gl = cache.gl;
 
   if (!gl) {
     return domNode;
@@ -348,35 +478,37 @@ var _WebGL_drawGL = F2(function (model, domNode) {
 
     var progid;
     var program;
+    var i;
+
     if (entity.__vert.id && entity.__frag.id) {
       progid = _WebGL_getProgID(entity.__vert.id, entity.__frag.id);
-      program = model.__cache.programs[progid];
+      program = cache.programs[progid];
     }
 
     if (!program) {
 
       var vshader;
       if (entity.__vert.id) {
-        vshader = model.__cache.shaders[entity.__vert.id];
+        vshader = cache.shaders[entity.__vert.id];
       } else {
         entity.__vert.id = _WebGL_guid++;
       }
 
       if (!vshader) {
         vshader = _WebGL_doCompile(gl, entity.__vert.src, gl.VERTEX_SHADER);
-        model.__cache.shaders[entity.__vert.id] = vshader;
+        cache.shaders[entity.__vert.id] = vshader;
       }
 
       var fshader;
       if (entity.__frag.id) {
-        fshader = model.__cache.shaders[entity.__frag.id];
+        fshader = cache.shaders[entity.__frag.id];
       } else {
         entity.__frag.id = _WebGL_guid++;
       }
 
       if (!fshader) {
         fshader = _WebGL_doCompile(gl, entity.__frag.src, gl.FRAGMENT_SHADER);
-        model.__cache.shaders[entity.__frag.id] = fshader;
+        cache.shaders[entity.__frag.id] = fshader;
       }
 
       var glProgram = _WebGL_doLink(gl, vshader, fshader);
@@ -397,7 +529,7 @@ var _WebGL_drawGL = F2(function (model, domNode) {
       );
 
       var numActiveAttributes = gl.getProgramParameter(glProgram, gl.ACTIVE_ATTRIBUTES);
-      for (var i = 0; i < numActiveAttributes; i++) {
+      for (i = 0; i < numActiveAttributes; i++) {
         var attribute = gl.getActiveAttrib(glProgram, i);
         var attribLocation = gl.getAttribLocation(glProgram, attribute.name);
         program.activeAttributes.push(attribute);
@@ -405,24 +537,23 @@ var _WebGL_drawGL = F2(function (model, domNode) {
       }
 
       progid = _WebGL_getProgID(entity.__vert.id, entity.__frag.id);
-      model.__cache.programs[progid] = program;
-
+      cache.programs[progid] = program;
     }
 
     gl.useProgram(program.glProgram);
 
     _WebGL_setUniforms(program.uniformSetters, entity.__uniforms);
 
-    var buffer = model.__cache.buffers.get(entity.__mesh);
+    var buffer = cache.buffers.get(entity.__mesh);
 
     if (!buffer) {
       buffer = _WebGL_doBindSetup(gl, entity.__mesh);
-      model.__cache.buffers.set(entity.__mesh, buffer);
+      cache.buffers.set(entity.__mesh, buffer);
     }
 
-    for (var i = 0; i < program.activeAttributes.length; i++) {
-      var attribute = program.activeAttributes[i];
-      var attribLocation = program.activeAttributeLocations[i];
+    for (i = 0; i < program.activeAttributes.length; i++) {
+      attribute = program.activeAttributes[i];
+      attribLocation = program.activeAttributeLocations[i];
 
       if (buffer.buffers[attribute.name] === undefined) {
         buffer.buffers[attribute.name] = _WebGL_doBindAttribute(gl, attribute, entity.__mesh, program.attributes);
@@ -443,7 +574,19 @@ var _WebGL_drawGL = F2(function (model, domNode) {
         }
       }
     }
-    _WebGL_listEach(__WI_enableSetting(gl), entity.__settings);
+
+    // Apply all the new settings
+    cache.toggle = !cache.toggle;
+    _WebGL_listEach(__WI_enableSetting(cache), entity.__settings);
+    // Disable the settings that were applied in the previous draw call
+    for (i = 0; i < _WebGL_settings.length; i++) {
+      var setting = cache[_WebGL_settings[i]];
+      if (setting.toggle !== cache.toggle && setting.enabled) {
+        _WebGL_disableFunctions[i](cache);
+        setting.enabled = false;
+        setting.toggle = cache.toggle;
+      }
+    }
 
     if (buffer.indexBuffer) {
       gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, buffer.indexBuffer);
@@ -451,9 +594,6 @@ var _WebGL_drawGL = F2(function (model, domNode) {
     } else {
       gl.drawArrays(entity.__mesh.a.__$mode, 0, buffer.numIndices);
     }
-
-    _WebGL_listEach(__WI_disableSetting(model.__cache), entity.__settings);
-
   }
 
   _WebGL_listEach(drawEntity, model.__entities);
@@ -464,6 +604,7 @@ function _WebGL_createUniformSetters(gl, model, program, uniformsMap) {
   var glProgram = program.glProgram;
   var currentUniforms = program.currentUniforms;
   var textureCounter = 0;
+  var cache = model.__cache;
   function createUniformSetter(glProgram, uniform) {
     var uniformName = uniform.name;
     var uniformLocation = gl.getUniformLocation(glProgram, uniformName);
@@ -513,13 +654,13 @@ function _WebGL_createUniformSetters(gl, model, program, uniformsMap) {
       case gl.SAMPLER_2D:
         var currentTexture = textureCounter++;
         return function (texture) {
-          if (currentUniforms[uniformName] !== value) {
+          if (currentUniforms[uniformName] !== texture) {
             gl.activeTexture(gl.TEXTURE0 + currentTexture);
-            var tex = model.__cache.textures.get(texture);
+            var tex = cache.textures.get(texture);
             if (!tex) {
               _WebGL_log('Created texture');
               tex = texture.__$createTexture(gl);
-              model.__cache.textures.set(texture, tex);
+              cache.textures.set(texture, tex);
             }
             gl.bindTexture(gl.TEXTURE_2D, tex);
             gl.uniform1i(uniformLocation, currentTexture);
@@ -530,7 +671,7 @@ function _WebGL_createUniformSetters(gl, model, program, uniformsMap) {
         return function (value) {
           if (currentUniforms[uniformName] !== value) {
             gl.uniform1i(uniformLocation, value);
-            currentUniforms[uniformName] = texture;
+            currentUniforms[uniformName] = value;
           }
         };
       default:
@@ -652,6 +793,20 @@ function _WebGL_render(model) {
     });
 
     model.__cache.gl = gl;
+
+    // Cache the current settings in order to diff them to avoid redundant calls
+    // https://emscripten.org/docs/optimizing/Optimizing-WebGL.html#avoid-redundant-calls
+    model.__cache.toggle = false; // used to diff the settings from the previous and current draw calls
+    model.__cache.blend = { enabled: false, toggle: false };
+    model.__cache.depthTest = { enabled: false, toggle: false };
+    model.__cache.stencilTest = { enabled: false, toggle: false };
+    model.__cache.scissor = { enabled: false, toggle: false };
+    model.__cache.colorMask = { enabled: false, toggle: false };
+    model.__cache.cullFace = { enabled: false, toggle: false };
+    model.__cache.polygonOffset = { enabled: false, toggle: false };
+    model.__cache.sampleCoverage = { enabled: false, toggle: false };
+    model.__cache.sampleAlphaToCoverage = { enabled: false, toggle: false };
+
     model.__cache.shaders = [];
     model.__cache.programs = {};
     model.__cache.buffers = new WeakMap();

--- a/src/Elm/Kernel/WebGL.js
+++ b/src/Elm/Kernel/WebGL.js
@@ -234,31 +234,42 @@ var _WebGL_enableSampleAlphaToCoverage = function (cache) {
 };
 
 var _WebGL_disableBlend = function (cache) {
-  cache.gl.disable(cache.gl.BLEND);
+  if (cache.blend.enabled) {
+    cache.gl.disable(cache.gl.BLEND);
+    cache.blend.enabled = false;
+  }
 };
 
 var _WebGL_disableDepthTest = function (cache) {
-  cache.gl.disable(cache.gl.DEPTH_TEST);
-  cache.gl.depthMask(true);
-  cache.depthTest.b = true;
+  if (cache.depthTest.enabled) {
+    cache.gl.disable(cache.gl.DEPTH_TEST);
+    cache.depthTest.enabled = false;
+  }
 };
 
 var _WebGL_disableStencilTest = function (cache) {
-  cache.gl.disable(cache.gl.STENCIL_TEST);
-  cache.gl.stencilMask(cache.STENCIL_WRITEMASK);
-  cache.stencilTest.c = cache.STENCIL_WRITEMASK;
+  if (cache.stencilTest.enabled) {
+    cache.gl.disable(cache.gl.STENCIL_TEST);
+    cache.stencilTest.enabled = false;
+  }
 };
 
 var _WebGL_disableScissor = function (cache) {
-  cache.gl.disable(cache.gl.SCISSOR_TEST);
+  if (cache.scissor.enabled) {
+    cache.gl.disable(cache.gl.SCISSOR_TEST);
+    cache.scissor.enabled = false;
+  }
 };
 
 var _WebGL_disableColorMask = function (cache) {
-  cache.gl.colorMask(true, true, true, true);
-  cache.colorMask.a = true;
-  cache.colorMask.b = true;
-  cache.colorMask.c = true;
-  cache.colorMask.d = true;
+  var colorMask = cache.colorMask;
+  if (!colorMask.a || !colorMask.b || !colorMask.c || !colorMask.d) {
+    cache.gl.colorMask(true, true, true, true);
+    colorMask.a = true;
+    colorMask.b = true;
+    colorMask.c = true;
+    colorMask.d = true;
+  }
 };
 
 var _WebGL_disableCullFace = function (cache) {
@@ -453,6 +464,17 @@ var _WebGL_drawGL = F2(function (model, domNode) {
   }
 
   gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+
+  if (!cache.depthTest.b) {
+    gl.depthMask(true);
+    cache.depthTest.b = true;
+  }
+  if (cache.stencilTest.c !== cache.STENCIL_WRITEMASK) {
+    gl.stencilMask(cache.STENCIL_WRITEMASK);
+    cache.stencilTest.c = cache.STENCIL_WRITEMASK;
+  }
+  _WebGL_disableScissor(cache);
+  _WebGL_disableColorMask(cache);
   gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
 
   function drawEntity(entity) {

--- a/src/Elm/Kernel/WebGL.js
+++ b/src/Elm/Kernel/WebGL.js
@@ -638,14 +638,14 @@ function _WebGL_createUniformSetters(gl, model, program, uniformsMap) {
       case gl.SAMPLER_2D:
         var currentTexture = textureCounter++;
         return function (texture) {
+          gl.activeTexture(gl.TEXTURE0 + currentTexture);
+          var tex = cache.textures.get(texture);
+          if (!tex) {
+            tex = texture.__$createTexture(gl);
+            cache.textures.set(texture, tex);
+          }
+          gl.bindTexture(gl.TEXTURE_2D, tex);
           if (currentUniforms[uniformName] !== texture) {
-            gl.activeTexture(gl.TEXTURE0 + currentTexture);
-            var tex = cache.textures.get(texture);
-            if (!tex) {
-              tex = texture.__$createTexture(gl);
-              cache.textures.set(texture, tex);
-            }
-            gl.bindTexture(gl.TEXTURE_2D, tex);
             gl.uniform1i(uniformLocation, currentTexture);
             currentUniforms[uniformName] = texture;
           }

--- a/src/WebGL/Internal.elm
+++ b/src/WebGL/Internal.elm
@@ -1,7 +1,6 @@
 module WebGL.Internal exposing
     ( Option(..)
     , Setting(..)
-    , disableSetting
     , enableOption
     , enableSetting
     )
@@ -53,62 +52,31 @@ type Setting
 
 
 enableSetting : () -> Setting -> ()
-enableSetting gl setting =
+enableSetting cache setting =
     case setting of
         Blend _ _ _ _ _ _ _ _ _ _ ->
-            Elm.Kernel.WebGL.enableBlend gl setting
+            Elm.Kernel.WebGL.enableBlend cache setting
 
         DepthTest _ _ _ _ ->
-            Elm.Kernel.WebGL.enableDepthTest gl setting
+            Elm.Kernel.WebGL.enableDepthTest cache setting
 
         StencilTest _ _ _ _ _ _ _ _ _ _ _ ->
-            Elm.Kernel.WebGL.enableStencilTest gl setting
+            Elm.Kernel.WebGL.enableStencilTest cache setting
 
         Scissor _ _ _ _ ->
-            Elm.Kernel.WebGL.enableScissor gl setting
+            Elm.Kernel.WebGL.enableScissor cache setting
 
         ColorMask _ _ _ _ ->
-            Elm.Kernel.WebGL.enableColorMask gl setting
+            Elm.Kernel.WebGL.enableColorMask cache setting
 
         CullFace _ ->
-            Elm.Kernel.WebGL.enableCullFace gl setting
+            Elm.Kernel.WebGL.enableCullFace cache setting
 
         PolygonOffset _ _ ->
-            Elm.Kernel.WebGL.enablePolygonOffset gl setting
+            Elm.Kernel.WebGL.enablePolygonOffset cache setting
 
         SampleCoverage _ _ ->
-            Elm.Kernel.WebGL.enableSampleCoverage gl setting
+            Elm.Kernel.WebGL.enableSampleCoverage cache setting
 
         SampleAlphaToCoverage ->
-            Elm.Kernel.WebGL.enableSampleAlphaToCoverage gl setting
-
-
-disableSetting : () -> Setting -> ()
-disableSetting cache setting =
-    case setting of
-        Blend _ _ _ _ _ _ _ _ _ _ ->
-            Elm.Kernel.WebGL.disableBlend cache
-
-        DepthTest _ _ _ _ ->
-            Elm.Kernel.WebGL.disableDepthTest cache
-
-        StencilTest _ _ _ _ _ _ _ _ _ _ _ ->
-            Elm.Kernel.WebGL.disableStencilTest cache
-
-        Scissor _ _ _ _ ->
-            Elm.Kernel.WebGL.disableScissor cache
-
-        ColorMask _ _ _ _ ->
-            Elm.Kernel.WebGL.disableColorMask cache
-
-        CullFace _ ->
-            Elm.Kernel.WebGL.disableCullFace cache
-
-        PolygonOffset _ _ ->
-            Elm.Kernel.WebGL.disablePolygonOffset cache
-
-        SampleCoverage _ _ ->
-            Elm.Kernel.WebGL.disableSampleCoverage cache
-
-        SampleAlphaToCoverage ->
-            Elm.Kernel.WebGL.disableSampleAlphaToCoverage cache
+            Elm.Kernel.WebGL.enableSampleAlphaToCoverage cache


### PR DESCRIPTION
Closes #23 and #26 

This PR improves webgl performance by reducing the number of gl calls. For more information [click here](https://emscripten.org/docs/optimizing/Optimizing-WebGL.html#avoid-redundant-calls)

* the uniforms are diffed using `===` to avoid reuploading common scene parameters like camera matrix or lights
* attribute locations are cached so that they don't have to be retrieved for every draw call
* webgl rendering settings are diffed against the JavaScript snapshot

Most of this was done together with @ianmackenzie. He also set up a test scene using the soon-to-be-released elm-3d-scene package, that we used to benchmark the performance:

![Screenshot 2020-06-26 at 21 53 38](https://user-images.githubusercontent.com/43472/85896569-02352b00-b7f9-11ea-9333-eea99365498b.png)

@MartinSStewart, who had opened the original issue, provided the source code of his game. Here you can see that it got slightly better:

![Screenshot 2020-06-25 at 21 45 06](https://user-images.githubusercontent.com/43472/85896730-4f190180-b7f9-11ea-8088-0078d66b48a7.png)

Here you can see the absence of redundant calls: 

![Screenshot 2020-06-25 at 21 56 14](https://user-images.githubusercontent.com/43472/85896763-5e984a80-b7f9-11ea-8f86-d5416976fe2d.png)

There were a lot of bugs, because of the stateful nature of webgl. In order to ensure that it works, I tested it using the following projects:

- https://github.com/elm-explorations/webgl/tree/master/examples
- https://github.com/ianmackenzie/elm-3d-scene/tree/master/examples
- https://github.com/ianmackenzie/elm-3d-scene/tree/master/testing
- https://github.com/justgook/webgl-playground/tree/master/examples
- https://gitlab.com/MartinSStewart/hackman/
- https://github.com/nacmartin/elm-webgl-lessons
- https://github.com/w0rm/elm-mogee
- https://github.com/w0rm/elm-physics/tree/master/examples
- https://github.com/w0rm/elm-street-404
- https://github.com/w0rm/elm-webgl-playground


















