### PR TITLE
Parallelise shader compilation

### DIFF
--- a/src/Elm/Kernel/WebGL.js
+++ b/src/Elm/Kernel/WebGL.js
@@ -295,10 +295,6 @@ function _WebGL_doCompile(gl, src, type) {
   var shader = gl.createShader(type);
   gl.shaderSource(shader, src);
   gl.compileShader(shader);
-  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-    throw gl.getShaderInfoLog(shader);
-  }
-
   return shader;
 }
 
@@ -309,7 +305,9 @@ function _WebGL_doLink(gl, vshader, fshader) {
   gl.attachShader(program, fshader);
   gl.linkProgram(program);
   if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-    throw gl.getProgramInfoLog(program);
+    throw ('Link failed: ' + gl.getProgramInfoLog(program) +
+      '\nvs info-log: ' + gl.getShaderInfoLog(vshader) +
+      '\nfs info-log: ' + gl.getShaderInfoLog(fshader));
   }
 
   return program;


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#Compile_Shaders_and_Link_Programs_in_parallel

> Don't check shader compile status until linking fails
> querying compile status is a synchronous call, which breaks pipelining