### PR TITLE
Enable OES_element_index_uint to support large meshes

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -10,7 +10,7 @@ version=$(grep -m1 version elm.json | awk -F: '{ print $2 }' | sed 's/[", ]//g')
 git commit -a -m "Bump to $version"
 git push
 
-cleanup="examples gh-pages.sh pipeline.png CONTRIBUTING.md .eslintrc.json release.sh"
+cleanup="examples sandbox gh-pages.sh pipeline.png CONTRIBUTING.md .eslintrc.json release.sh"
 last_commit=$(git rev-parse HEAD)
 
 git clone --reference . git@github.com:elm-explorations/webgl.git release

--- a/sandbox/IndexedTriangles.elm
+++ b/sandbox/IndexedTriangles.elm
@@ -1,0 +1,150 @@
+module IndexedTriangles exposing (main)
+
+{-
+   This module fills the canvas with many tiny triangles.
+
+   It is used to test WebGL.indexedTriangles
+
+   With OES_element_index_uint extension we can support
+   element indices that are bigger than 65536
+-}
+
+import Html exposing (Html)
+import Html.Attributes exposing (height, style, width)
+import Math.Vector2 exposing (Vec2, vec2)
+import Math.Vector3 exposing (Vec3, vec3)
+import WebGL exposing (Mesh, Shader)
+
+
+main : Html msg
+main =
+    WebGL.toHtml
+        [ width 400
+        , height 400
+        , style "display" "block"
+        ]
+        [ WebGL.entity
+            vertexShader
+            fragmentShader
+            mesh
+            {}
+        ]
+
+
+
+-- Mesh
+
+
+type alias Vertex =
+    { position : Vec2
+    , color : Vec3
+    }
+
+
+scale : Int
+scale =
+    let
+        -- this is the limit of WebGL 1.0
+        maxNumberOfIndices =
+            65536
+    in
+    round (sqrt (toFloat maxNumberOfIndices)) + 1
+
+
+mesh : Mesh Vertex
+mesh =
+    let
+        dimension =
+            List.range 0 scale
+
+        vertices =
+            List.foldl
+                (\i result ->
+                    List.foldl
+                        (\j ->
+                            let
+                                x =
+                                    toFloat i / toFloat scale * 2 - 1
+
+                                y =
+                                    toFloat j / toFloat scale * 2 - 1
+                            in
+                            (::)
+                                { position = vec2 x y
+                                , color =
+                                    if modBy 2 i == 1 then
+                                        vec3 1 0 0
+
+                                    else if modBy 2 j == 1 then
+                                        vec3 0 1 0
+
+                                    else
+                                        vec3 0 0 1
+                                }
+                        )
+                        result
+                        dimension
+                )
+                []
+                dimension
+
+        dimensionsToIndex i j =
+            i * (scale + 1) + j
+
+        indices =
+            List.foldl
+                (\i result ->
+                    List.foldl
+                        (\j ->
+                            (++)
+                                [ ( dimensionsToIndex (i - 1) (j - 1)
+                                  , dimensionsToIndex i (j - 1)
+                                  , dimensionsToIndex (i - 1) j
+                                  )
+                                , ( dimensionsToIndex i (j - 1)
+                                  , dimensionsToIndex i j
+                                  , dimensionsToIndex (i - 1) j
+                                  )
+                                ]
+                        )
+                        result
+                        (List.drop 1 dimension)
+                )
+                []
+                (List.drop 1 dimension)
+    in
+    WebGL.indexedTriangles (Debug.log "v" vertices) (Debug.log "i" indices)
+
+
+
+-- Shaders
+
+
+vertexShader : Shader Vertex {} { vcolor : Vec3 }
+vertexShader =
+    [glsl|
+
+        attribute vec2 position;
+        attribute vec3 color;
+        varying vec3 vcolor;
+
+        void main () {
+            gl_Position = vec4(position, 0.0, 1.0);
+            vcolor = color;
+        }
+
+    |]
+
+
+fragmentShader : Shader {} {} { vcolor : Vec3 }
+fragmentShader =
+    [glsl|
+
+        precision mediump float;
+        varying vec3 vcolor;
+
+        void main () {
+            gl_FragColor = vec4(vcolor, 1.0);
+        }
+
+    |]

--- a/sandbox/Intersection.elm
+++ b/sandbox/Intersection.elm
@@ -5,7 +5,7 @@ module Intersection exposing (main)
    visible in the intercection with the red triangle.
    A green outline marks a hidden area of the green triangle.
 
-   This example helps to understand the separate stencil test.
+   This example helps to test the separate stencil test.
 -}
 
 import Html exposing (Html)

--- a/sandbox/elm.json
+++ b/sandbox/elm.json
@@ -1,0 +1,26 @@
+{
+  "type": "application",
+  "source-directories": [
+      "."
+  ],
+  "elm-version": "0.19.1",
+  "dependencies": {
+      "direct": {
+          "elm/browser": "1.0.0",
+          "elm/core": "1.0.0",
+          "elm/html": "1.0.0",
+          "elm/json": "1.0.0",
+          "elm-explorations/linear-algebra": "1.0.0",
+          "elm-explorations/webgl": "1.1.2"
+      },
+      "indirect": {
+          "elm/time": "1.0.0",
+          "elm/url": "1.0.0",
+          "elm/virtual-dom": "1.0.0"
+      }
+  },
+  "test-dependencies": {
+      "direct": {},
+      "indirect": {}
+  }
+}

--- a/src/Elm/Kernel/WebGL.js
+++ b/src/Elm/Kernel/WebGL.js
@@ -432,10 +432,10 @@ function _WebGL_doBindSetup(gl, mesh) {
  *
  *  @param {List} indicesList the list of indices
  *  @param {Number} indexSize the size of the index
- *  @return {Uint16Array} indices
+ *  @return {Uint32Array} indices
  */
 function _WebGL_makeIndexedBuffer(indicesList, indexSize) {
-  var indices = new Uint16Array(_WebGL_listLength(indicesList) * indexSize);
+  var indices = new Uint32Array(_WebGL_listLength(indicesList) * indexSize);
   var fillOffset = 0;
   var i;
   _WebGL_listEach(function (elem) {
@@ -598,7 +598,7 @@ var _WebGL_drawGL = F2(function (model, domNode) {
 
     if (buffer.indexBuffer) {
       gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, buffer.indexBuffer);
-      gl.drawElements(entity.__mesh.a.__$mode, buffer.numIndices, gl.UNSIGNED_SHORT, 0);
+      gl.drawElements(entity.__mesh.a.__$mode, buffer.numIndices, gl.UNSIGNED_INT, 0);
     } else {
       gl.drawArrays(entity.__mesh.a.__$mode, 0, buffer.numIndices);
     }
@@ -797,8 +797,9 @@ function _WebGL_render(model) {
       sceneSetting(gl);
     });
 
-    // Activate OES_standard_derivatives extension
+    // Activate extensions
     gl.getExtension('OES_standard_derivatives');
+    gl.getExtension('OES_element_index_uint');
 
     model.__cache.gl = gl;
 

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -51,7 +51,7 @@ before trying to do too much with just the documentation provided here.
 import Elm.Kernel.WebGL
 import Html exposing (Attribute, Html)
 import WebGL.Internal as I
-import WebGL.Settings as Settings exposing (Setting)
+import WebGL.Settings exposing (Setting)
 import WebGL.Settings.DepthTest as DepthTest
 
 


### PR DESCRIPTION
Closes #35

Set up the test case that renders a mesh with very large indices. Before this change, it would render:

<img width="400" alt="Screenshot 2021-02-06 at 19 09 49" src="https://user-images.githubusercontent.com/43472/107126614-3c979800-68b1-11eb-8590-5395a53d36b8.png">

After the fix, everything is rendered correctly:

<img width="407" alt="Screenshot 2021-02-06 at 19 20 48" src="https://user-images.githubusercontent.com/43472/107126622-47eac380-68b1-11eb-938b-22be97b397ff.png">


